### PR TITLE
Update InstagramResourceOwner.php

### DIFF
--- a/src/Provider/InstagramResourceOwner.php
+++ b/src/Provider/InstagramResourceOwner.php
@@ -76,6 +76,6 @@ class InstagramResourceOwner implements ResourceOwnerInterface
      */
     public function toArray()
     {
-        return $this->response;
+        return $this->response['data'];
     }
 }

--- a/test/src/Provider/InstagramTest.php
+++ b/test/src/Provider/InstagramTest.php
@@ -108,15 +108,15 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
         $user = $this->provider->getResourceOwner($token);
 
         $this->assertEquals($userId, $user->getId());
-        $this->assertEquals($userId, $user->toArray()['data']['id']);
+        $this->assertEquals($userId, $user->toArray()['id']);
         $this->assertEquals($name, $user->getName());
-        $this->assertEquals($name, $user->toArray()['data']['full_name']);
+        $this->assertEquals($name, $user->toArray()['full_name']);
         $this->assertEquals($nickname, $user->getNickname());
-        $this->assertEquals($nickname, $user->toArray()['data']['username']);
+        $this->assertEquals($nickname, $user->toArray()['username']);
         $this->assertEquals($picture, $user->getImageurl());
-        $this->assertEquals($picture, $user->toArray()['data']['profile_picture']);
+        $this->assertEquals($picture, $user->toArray()['profile_picture']);
         $this->assertEquals($description, $user->getDescription());
-        $this->assertEquals($description, $user->toArray()['data']['bio']);
+        $this->assertEquals($description, $user->toArray()['bio']);
     }
 
     /**


### PR DESCRIPTION
Implementation of ResourceOwnerInterface::toArray() should "Return all of the owner details available as an array". InstagramResourceOwner::toArray() returned the full response, which includes a "token" and "meta" key as well. This makes the oauth2-instagram package not so drop-in-able :)
