### PR TITLE
Provide a functioning `getAuthenticatedRequest()` for Instagram

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "league/oauth2-client": "~1.0"
+        "league/oauth2-client": "~1.0",
+        "jakeasmith/http_build_url": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -64,6 +64,26 @@ class Instagram extends AbstractProvider
         return 'https://api.instagram.com/v1/users/self?access_token='.$token;
     }
 
+    public function getAuthenticatedRequest($method, $url, $token, array $options = [])
+    {
+        $parsedUrl = \parse_url($url);
+        $queryString = array();
+
+        if (isset($parsedUrl['query'])) {
+            parse_str($parsedUrl['query'], $queryString);
+        }
+
+        if (!isset($queryString['access_token'])) {
+            $queryString['access_token'] = (string) $token;
+        }
+
+        $url = \http_build_url($url, [
+            'query' => \http_build_query($queryString),
+        ]);
+
+        return $this->createRequest($method, $url, null, $options);
+    }
+
     /**
      * Get the default scopes used by this provider.
      *


### PR DESCRIPTION
**TL;DR:** This adds the `access_token` query string parameter to the URL in order to return a properly authenticated Instagram request. More background details follow.

---

AbstractProvider provides a basic `getAuthenticatedRequest()` method, which the Instagram provider was using unchanged. This method creates a request, and in doing so, merges in the headers array returned by `getAuthorizationHeaders()`, which is an empty array in the AbstractProvider.

The base package provides a BearerAuthorizationTrait that providers may use in order to override `getAuthorizationHeaders()` and set an Authorization header using Bearer token authentication on all requests, in order to request a properly authenticated request.

Instagram, however, does not support the use of the Authorization header for authenticated requests. Instead, the `access_token` parameter must be present in the query string of all authenticated requests.
