### PR TITLE
handle OAuthException error response format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea

--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -108,10 +108,20 @@ class Instagram extends AbstractProvider
      */
     protected function checkResponse(ResponseInterface $response, $data)
     {
-        if (isset($data['meta']['error_type'])) {
+        // standard error response format
+        if (!empty($data['meta']['error_type'])) {
             throw new IdentityProviderException(
                 $data['meta']['error_message'] ?: $response->getReasonPhrase(),
                 $data['meta']['code'] ?: $response->getStatusCode(),
+                $response
+            );
+        }
+
+        // OAuthException error response format
+        if (!empty($data['error_type'])) {
+            throw new IdentityProviderException(
+                $data['error_message'] ?: $response->getReasonPhrase(),
+                $data['code'] ?: $response->getStatusCode(),
                 $response
             );
         }
@@ -122,7 +132,7 @@ class Instagram extends AbstractProvider
      *
      * @param array $response
      * @param AccessToken $token
-     * @return League\OAuth2\Client\Provider\ResourceOwnerInterface
+     * @return \League\OAuth2\Client\Provider\ResourceOwnerInterface
      */
     protected function createResourceOwner(array $response, AccessToken $token)
     {

--- a/test/src/Provider/InstagramTest.php
+++ b/test/src/Provider/InstagramTest.php
@@ -136,7 +136,27 @@ class InstagramTest extends \PHPUnit_Framework_TestCase
             ->times(1)
             ->andReturn($postResponse);
         $this->provider->setHttpClient($client);
-        $token = $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+        $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
+    }
+
+    /**
+     * @expectedException League\OAuth2\Client\Provider\Exception\IdentityProviderException
+     **/
+    public function testExceptionThrownWhenAuthErrorObjectReceived()
+    {
+        $message = uniqid();
+        $status = rand(400,600);
+        $postResponse = m::mock('Psr\Http\Message\ResponseInterface');
+        $postResponse->shouldReceive('getBody')->andReturn('{"error_type": "OAuthException","code": '.$status.',"error_message": "'.$message.'"}');
+        $postResponse->shouldReceive('getHeader')->andReturn(['content-type' => 'json']);
+        $postResponse->shouldReceive('getStatusCode')->andReturn($status);
+
+        $client = m::mock('GuzzleHttp\ClientInterface');
+        $client->shouldReceive('send')
+            ->times(1)
+            ->andReturn($postResponse);
+        $this->provider->setHttpClient($client);
+        $this->provider->getAccessToken('authorization_code', ['code' => 'mock_authorization_code']);
     }
 
     public function testGetAuthenticatedRequest()


### PR DESCRIPTION
Unfortunately, Instagram responses are a bit inconsistent when it comes to errors returned by their API. 

this pull request handles cases when errors are returned without "meta" key, such as:

```
{
    "code": 400,
    "error_type": "OAuthException",
    "error_message": "No matching code found."
}
```

see http://stackoverflow.com/questions/23886843/instagram-oauth-api-gives-code-400-error-type-oauthexception-error for a sample response case
