### PR TITLE
Update to Instagram Basic Display API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Changelog
 All Notable changes to `oauth2-instagram` will be documented in this file
 
+## 3.0.0 - 2020-02-25
+
+### Added
+- Support for Instagram Basic Display API
+  - get Resource Owner Details from https://graph.instagram.com/me
+  - changed default scopes to `['user_profile']`
+- Custom host configuration for Graph API host
+
+### Deprecated
+- Nothing
+
+### Fixed
+- Nothing
+
+### Removed
+- Support for Instagram Legacy API (https://api.instagram.com/v1/...)
+- Short-hand functions for now removed attributes
+  - `InstagramResourceOwner::getImageUrl()`
+  - `InstagramResourceOwner::getName()`
+  - `InstagramResourceOwner::getDescription()`
+
+### Security
+- Nothing
+
 ## 2.0.0 - 2017-01-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ $provider = new League\OAuth2\Client\Provider\Instagram([
     'clientId'          => '{instagram-client-id}',
     'clientSecret'      => '{instagram-client-secret}',
     'redirectUri'       => 'https://example.com/callback-url',
-    'host'              => 'https://api.instagram.com' // Optional, defaults to https://api.instagram.com
+    'host'              => 'https://api.instagram.com',  // Optional, defaults to https://api.instagram.com
+    'graphHost'         => 'https://graph.instagram.com' // Optional, defaults to https://graph.instagram.com
 ]);
 
 if (!isset($_GET['code'])) {
@@ -58,7 +59,7 @@ if (!isset($_GET['code'])) {
         $user = $provider->getResourceOwner($token);
 
         // Use these details to create a new profile
-        printf('Hello %s!', $user->getName());
+        printf('Hello %s!', $user->getNickname());
 
     } catch (Exception $e) {
 
@@ -78,19 +79,17 @@ When creating your Instagram authorization URL, you can specify the state and sc
 ```php
 $options = [
     'state' => 'OPTIONAL_CUSTOM_CONFIGURED_STATE',
-    'scope' => ['basic','likes','comments'] // array or string
+    'scope' => ['user_profile', 'user_media'] // array or string
 ];
 
 $authorizationUrl = $provider->getAuthorizationUrl($options);
 ```
 If neither are defined, the provider will utilize internal defaults.
 
-At the time of authoring this documentation, the [following scopes are available](https://instagram.com/developer/authentication/#scope).
+At the time of authoring this documentation, the [following scopes are available](https://developers.facebook.com/docs/instagram-basic-display-api/overview#permissions).
 
-- basic
-- comments
-- relationships
-- likes
+- user_profile
+- user_media
 
 ## Testing
 

--- a/src/Provider/Exception/InstagramIdentityProviderException.php
+++ b/src/Provider/Exception/InstagramIdentityProviderException.php
@@ -20,11 +20,11 @@ class InstagramIdentityProviderException extends IdentityProviderException
         $code = $response->getStatusCode();
         $body = (string) $response->getBody();
 
-        if (isset($data['meta'], $data['meta']['error_message'])) {
-            $message = $data['meta']['error_message'];
+        if (isset($data['error'], $data['error']['message'])) {
+            $message = $data['error']['message'];
         }
-        if (isset($data['meta'], $data['meta']['code'])) {
-            $code = $data['meta']['code'];
+        if (isset($data['error'], $data['error']['code'])) {
+            $code = $data['error']['code'];
         }
 
         return new static($message, $code, $body);

--- a/src/Provider/Instagram.php
+++ b/src/Provider/Instagram.php
@@ -11,14 +11,14 @@ class Instagram extends AbstractProvider
     /**
      * @var string Key used in a token response to identify the resource owner.
      */
-    const ACCESS_TOKEN_RESOURCE_OWNER_ID = 'user.id';
+    const ACCESS_TOKEN_RESOURCE_OWNER_ID = 'user_id';
 
     /**
      * Default scopes
      *
      * @var array
      */
-    public $defaultScopes = ['basic'];
+    public $defaultScopes = ['user_profile'];
 
     /**
      * Default host
@@ -28,6 +28,13 @@ class Instagram extends AbstractProvider
     protected $host = 'https://api.instagram.com';
 
     /**
+     * Default Graph API host
+     *
+     * @var string
+     */
+    protected $graphHost = 'https://graph.instagram.com';
+
+    /**
      * Gets host.
      *
      * @return string
@@ -35,6 +42,16 @@ class Instagram extends AbstractProvider
     public function getHost()
     {
         return $this->host;
+    }
+
+    /**
+     * Gets Graph API host.
+     *
+     * @return string
+     */
+    public function getGraphHost()
+    {
+        return $this->graphHost;
     }
 
     /**
@@ -78,7 +95,7 @@ class Instagram extends AbstractProvider
      */
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        return $this->host.'/v1/users/self?access_token='.$token;
+        return $this->graphHost.'/me?fields=id,username&access_token='.$token;
     }
 
     /**
@@ -127,7 +144,6 @@ class Instagram extends AbstractProvider
     /**
      * Check a provider response for errors.
      *
-     * @link   https://instagram.com/developer/endpoints/
      * @throws IdentityProviderException
      * @param  ResponseInterface $response
      * @param  string $data Parsed response data
@@ -136,7 +152,7 @@ class Instagram extends AbstractProvider
     protected function checkResponse(ResponseInterface $response, $data)
     {
         // Standard error response format
-        if (!empty($data['meta']['error_type'])) {
+        if (!empty($data['error'])) {
             throw InstagramIdentityProviderException::clientException($response, $data);
         }
 
@@ -168,6 +184,20 @@ class Instagram extends AbstractProvider
     public function setHost($host)
     {
         $this->host = $host;
+
+        return $this;
+    }
+
+    /**
+     * Sets Graph API host.
+     *
+     * @param string $host
+     *
+     * @return string
+     */
+    public function setGraphHost($host)
+    {
+        $this->graphHost = $host;
 
         return $this;
     }

--- a/src/Provider/InstagramResourceOwner.php
+++ b/src/Provider/InstagramResourceOwner.php
@@ -26,27 +26,7 @@ class InstagramResourceOwner implements ResourceOwnerInterface
      */
     public function getId()
     {
-        return $this->response['data']['id'] ?: null;
-    }
-
-    /**
-     * Get user imageurl
-     *
-     * @return string|null
-     */
-    public function getImageurl()
-    {
-        return $this->response['data']['profile_picture'] ?: null;
-    }
-
-    /**
-     * Get user name
-     *
-     * @return string|null
-     */
-    public function getName()
-    {
-        return $this->response['data']['full_name'] ?: null;
+        return $this->response['id'] ?: null;
     }
 
     /**
@@ -56,17 +36,7 @@ class InstagramResourceOwner implements ResourceOwnerInterface
      */
     public function getNickname()
     {
-        return $this->response['data']['username'] ?: null;
-    }
-
-    /**
-     * Get user description
-     *
-     * @return string|null
-     */
-    public function getDescription()
-    {
-        return $this->response['data']['bio'] ?: null;
+        return $this->response['username'] ?: null;
     }
 
     /**
@@ -76,6 +46,6 @@ class InstagramResourceOwner implements ResourceOwnerInterface
      */
     public function toArray()
     {
-        return $this->response['data'];
+        return $this->response;
     }
 }


### PR DESCRIPTION
As announced [here [1]](1) Instagram is deprecating its Legacy API to move to a Graph API.  On **March 31, 2020** the Legacy API will be shut down rendering the current code of this plugin functionless since the Resource Owner will be no longer available via the used Legacy API using https://api.instagram.com/v1/users/self (or at least this is how I understand it; I find the information on this a bit confusing...).

This PR is introducing support for the new Graph API using the [Instagram Basic Display API [2]](https://developers.facebook.com/docs/instagram-basic-display-api).

Naturally since there are significant changes in the API and this plugin can only support the capabilities the underlying API offers there are some breaking changes especially the removal of some shot-hand functions to attributes of the Resource Owner which are no longer available via the Basic Display API. See the Readme.

[1] https://developers.facebook.com/blog/post/2019/10/15/launch-instagram-basic-display-api/
[2] https://developers.facebook.com/docs/instagram-basic-display-api