### PR TITLE
add exchange/refresh token feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,27 @@ if (!isset($_GET['code'])) {
 }
 ```
 
+### Requesting a long-lived access-token
+```php
+$token = $provider->getAccessToken('authorization_code', [
+    'code' => $_GET['code']
+]);
+    
+$longLivedToken = $provider->getLongLivedAccessToken($token);
+```
+
+### Refreshing a long-lived access-token
+```php
+$token = $provider->getAccessToken('authorization_code', [
+    'code' => $_GET['code']
+]);
+
+// you need to fetch a long-lived token first!    
+$longLivedToken = $provider->getLongLivedAccessToken($token);
+
+$refreshedToken = $provider->getRefreshedAccessToken($longLivedToken);
+```
+
 ### Managing Scopes
 
 When creating your Instagram authorization URL, you can specify the state and scopes your application may authorize.

--- a/src/Grant/IgExchangeToken.php
+++ b/src/Grant/IgExchangeToken.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace League\OAuth2\Client\Grant;
+
+class IgExchangeToken extends AbstractGrant
+{
+    public function __toString()
+    {
+        return 'ig_exchange_token';
+    }
+
+    protected function getRequiredRequestParameters()
+    {
+        return [
+            'access_token',
+        ];
+    }
+
+    protected function getName()
+    {
+        return 'ig_exchange_token';
+    }
+}

--- a/src/Grant/IgRefreshToken.php
+++ b/src/Grant/IgRefreshToken.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace League\OAuth2\Client\Grant;
+
+class IgRefreshToken extends AbstractGrant
+{
+    public function __toString()
+    {
+        return 'ig_refresh_token';
+    }
+
+    protected function getRequiredRequestParameters()
+    {
+        return [
+            'access_token',
+        ];
+    }
+
+    protected function getName()
+    {
+        return 'ig_refresh_token';
+    }
+}


### PR DESCRIPTION
This PR:
- allows you to exchange a short-lived access token with a long-lived access-token (which should fix #15)
- allows you to refresh a long-lived token
- fixes two annotations return types
- fixes wrong Exception class (`IdentityProviderException` => `InstagramIdentityProviderException`)

### API Reference
https://developers.facebook.com/docs/instagram-basic-display-api/guides/long-lived-access-tokens